### PR TITLE
Adding version to the template.

### DIFF
--- a/.template/xet-tools.templ
+++ b/.template/xet-tools.templ
@@ -2,6 +2,7 @@ class XetTools < Formula
   desc "XetHub CLI Tools Homebrew Tap."
   homepage "https://github.com/xetdata/xet-tools"
   license :cannot_represent
+  version "%VERSION%"
 
   on_macos do
     url "%MAC_URL%"


### PR DESCRIPTION
Part 2 of the fix for https://github.com/xetdata/xethub/issues/1928.

This is the homebrew portion of the fix.

Part 2 of the fix is https://github.com/xetdata/xethub/pull/1931.